### PR TITLE
exclude technical urls and the search itself from search-index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -30,6 +30,14 @@ indices:
   # search
   search:
     target: /query-index-search.xlsx
+    exclude:
+      - /brand-nav
+      - /nav
+      - /footer
+      - /contacts/**
+      - /drafts/**
+      - /tools/**
+      - /suche
     properties:
       title:
         select: head > meta[property="og:title"]


### PR DESCRIPTION
Test URLs:

- Before: https://main--eds-eder-main--techdivision.aem.live/
- After: https://search-index-excludes--eds-eder-main--techdivision.aem.live/
