### PR TITLE
fixing attempt for empty h1 in content-report index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -195,7 +195,7 @@ indices:
       h1:
         select: h1:first-of-type
         value: |
-          attribute(el, 'content')
+          textContent(el)
       meta-title:
         select: head > meta[property="og:title"]
         value: |


### PR DESCRIPTION
Test URLs:

Before: https://main--eds-eder-main--techdivision.aem.live/
After: https://content-report-index--eds-eder-main--techdivision.aem.live/
