### PR TITLE
another fixing-attempt for mssing h1 in content-report index

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -193,7 +193,7 @@ indices:
     target: /content-report.xlsx
     properties:
       h1:
-        select: h1:first-of-type
+        select: main h1
         value: |
           textContent(el)
       meta-title:


### PR DESCRIPTION
Test URLs:

- Before: https://main--eds-eder-main--techdivision.aem.live/
- After: https://content-report-index--eds-eder-main--techdivision.aem.live/
