### PR TITLE
EDERCMS-137: Add no-headline contact block

### DIFF
--- a/blocks/contacts/contacts.js
+++ b/blocks/contacts/contacts.js
@@ -43,7 +43,7 @@ export default async function decorate(block) {
   });
 
   // add headline if sidebar contains contacts block
-  if (hasBodyClass('has-sidebar')) {
+  if (hasBodyClass('has-sidebar') && !block.classList.contains('no-headline')) {
     const contact = document.body.querySelector('.section.sidebar > .contacts-wrapper');
 
     if (contact && !contact.querySelector(':scope > .contact-headline')) {


### PR DESCRIPTION
[EDERCMS-#](https://techdivision.atlassian.net/browse/EDERCMS-137)

Test URLs:

- Before: https://main--eds-eder-main--techdivision.aem.live/drafts/morbitzerd/contact-no-headline
- After: https://feature-edercms-173--eds-eder-main--techdivision.hlx.live/drafts/morbitzerd/contact-no-headline
